### PR TITLE
update version spring cloud and kubernetes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-kubernetes-connector</artifactId>
-	<version>1.0.0.SERENITY-SNAPSHOT</version>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -13,7 +13,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<kubernetes.client.version>1.3.98</kubernetes.client.version>
+		<kubernetes.client.version>1.3.102</kubernetes.client.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-kubernetes-connector</artifactId>
-	<version>1.0.0.SERENITY</version>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
 		<version>1.1.1.RELEASE</version>
-		<relativePath />  <!-- lookup parent from repository -->
+		<relativePath />  <!-- lookup parent from  repository -->
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,18 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-kubernetes-connector</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.SERENITY-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.1.0.M4</version>
+		<version>1.1.1.RELEASE</version>
 		<relativePath />  <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<kubernetes.client.version>1.3.63</kubernetes.client.version>
+		<kubernetes.client.version>1.3.98</kubernetes.client.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-kubernetes-connector</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.SERENITY</version>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
Hi, 

We have updated the kubernetes client version to 1.3.102, with this version this library will be able to take the namespace inside the pod of openshift, and the spring cloud build version. These are two minimal changes, but very important things to add new functionality to the library.

```
<parent>
    <groupId>org.springframework.cloud</groupId>
    <artifactId>spring-cloud-build</artifactId>
    <version>1.1.1.RELEASE</version>
    <relativePath />  <!-- lookup parent from repository -->
</parent>

   <kubernetes.client.version>1.3.102</kubernetes.client.version>
```
