### PR TITLE
Update kubernetes client version and spring cloud build version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.1.0.M4</version>
+		<version>1.1.1.RELEASE</version>
 		<relativePath />  <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<kubernetes.client.version>1.3.63</kubernetes.client.version>
+		<kubernetes.client.version>1.3.102</kubernetes.client.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Hi,

We have updated the kubernetes client version to 1.3.102, with this version this library will be able to take the namespace inside the pod of openshift, and the spring cloud build version. These are two minimal changes, but very important things to add new functionality to the library.

```
<parent>
    <groupId>org.springframework.cloud</groupId>
    <artifactId>spring-cloud-build</artifactId>
    <version>1.1.1.RELEASE</version>
    <relativePath />  <!-- lookup parent from repository -->
</parent>
```

  `<kubernetes.client.version>1.3.102</kubernetes.client.version>`
