### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 image:https://build.spring.io/plugins/servlet/buildStatusImage/SCD-SCKC[Build Status, link=https://build.spring.io/browse/SCD-SCKC]
 
 
-The http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html[Spring Cloud Connector project] provides an abstraction to discover services at runtime and register them as Spring beans.  
+The https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html[Spring Cloud Connector project] provides an abstraction to discover services at runtime and register them as Spring beans.  
 
 This project provides support to discover Redis and RabbitMQ servers running on Kubernetes. The mechanism by which it performs the discovery is to look for a Kubernetes service whose name is `redis` or `rabbitmq` along with a label that has a key named `spirng-cloud-service`.  Here is an example taken from the https://github.com/spring-cloud/spring-cloud-dataflow-admin-kubernetes/blob/master/src/etc/kubernetes/redis-service.yml[redis-service.yml] definition used in the Spring Cloud DataFlow Kubernetes getting started project.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html) result 200).